### PR TITLE
Adjusted Audio Player Initialization

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -76,7 +76,7 @@ function formatToMinutes(duration: number): string {
 
 const AudioPlayer = ({ color, audioFiles }: AudioPlayerProps) => {
   const [audioFetched, setAudioFetched] = useState<boolean>(true);
-  const [currentSongIndex, setCurrentSongIndex] = useState<number>(-1);
+  const [currentSongIndex, setCurrentSongIndex] = useState<number>(0);
   const [isPlaying, setisPlaying] = useState<boolean>(false);
   const [volume, setVolume] = useState<number>(1);
   const [currentSong, setCurrentSong] = useState<AudioFileWithFiles | null>(


### PR DESCRIPTION
The player should now initialize to song index 0 instead of -1, which allows seeking within that song before playing any audio.