### PR TITLE
Fixed Bug with Song Autoplay

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -105,6 +105,7 @@ const AudioPlayer = ({ color, audioFiles }: AudioPlayerProps) => {
         audioPlayer.current.src = currentAudioUrl;
         audioPlayer.current.addEventListener('ended', handleEnded);
       }
+      if (isPlaying) audioPlayer.current.play();
     }
 
     return () => {
@@ -194,7 +195,7 @@ const AudioPlayer = ({ color, audioFiles }: AudioPlayerProps) => {
         audioPlayer.current?.pause();
         setCurrentSongIndex(0);
         setPause(false);
-        //audioPlayer.current.currentTime = 0;
+        audioPlayer.current.currentTime = 0;
       }
       setisPlaying(false);
     }


### PR DESCRIPTION
- Re-added autoplay of next songs after they finish (and without starting the playlist on load)
- Also adjusted the stop button to reset to the beginning of song 1 in a playlist instead of preserving the current timestamp