### PR TITLE
Preserved play state of Prev Song button

### DIFF
--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -228,8 +228,8 @@ const AudioPlayer = ({ color, audioFiles }: AudioPlayerProps) => {
       if (audioPlayer.current) {
         audioPlayer.current.currentTime = 0;
         audioPlayer.current.load();
-        if (!isPlaying) {
-          setisPlaying(true);
+        if (isPlaying) {
+          audioPlayer.current.play();
         }
       }
     } else {


### PR DESCRIPTION
If a song is currently playing & the PrevSong button is pressed, the previous song will immediately start playing